### PR TITLE
Improvements for Jekyll on local and deployment

### DIFF
--- a/.apk
+++ b/.apk
@@ -1,0 +1,2 @@
+git
+imagemagick

--- a/.apt
+++ b/.apt
@@ -1,0 +1,2 @@
+git
+imagemagick

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -14,13 +14,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.3
           bundler-cache: true
       # TODO: Uncomment this to use Tailwind CSS
       # - name: Setup Node
       #   uses: actions/setup-node@v2
       #   with:
-      #     node-version: '18'
+      #     node-version: '20'
       # - run: npm install
       - name: Install apt dependencies
         run: |

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -22,10 +22,10 @@ jobs:
       #   with:
       #     node-version: '18'
       # - run: npm install
-      - name: Install ImageMagick
+      - name: Install apt dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y imagemagick
+          sudo apt-get install -y $(cat .apt)
       - name: Build site
         uses: limjh16/jekyll-action-ts@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM jekyll/jekyll:latest
-
-# Install ImageMagick
-RUN apk add --no-cache imagemagick
-
-# Set working directory
-WORKDIR /srv/jekyll
-
-# The default command from the parent image will be used (jekyll serve)

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,6 @@ group :jekyll_plugins do
 end
 
 group :jekyll_thumbnail_img do
-  gem "jekyll-thumbnail-img", git: "https://github.com/S8A/jekyll-thumbnail-img.git", branch: "feature/resolve_width_variable"
+  gem "jekyll-thumbnail-img", git: "https://github.com/S8A/jekyll-thumbnail-img.git", branch: "feature/cache_thumbnails_and_allow_variable_width"
   gem "mini_magick"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -27,3 +27,7 @@ group :jekyll_thumbnail_img do
   gem "jekyll-thumbnail-img", git: "https://github.com/S8A/jekyll-thumbnail-img.git", branch: "feature/cache_thumbnails_and_allow_variable_width"
   gem "mini_magick"
 end
+
+# Workaround for segmentation fault on Alpine Linux
+# https://github.com/protocolbuffers/protobuf/issues/16853#issuecomment-2583135716
+gem "google-protobuf", force_ruby_platform: true if RUBY_PLATFORM.include?("linux-musl")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/S8A/jekyll-thumbnail-img.git
-  revision: 321c4dc51a5b45ea488a0d81e9e7320c91795659
-  branch: feature/resolve_width_variable
+  revision: 71e74a098a00219c8954130afe95ae45d535c2c5
+  branch: feature/cache_thumbnails_and_allow_variable_width
   specs:
     jekyll-thumbnail-img (0.1.2)
       jekyll
@@ -10,7 +10,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.2)
+    activesupport (8.0.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -22,49 +22,54 @@ GEM
       minitest (>= 5.1)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
     benchmark (0.4.0)
-    bigdecimal (3.1.8)
+    bigdecimal (3.1.9)
     colorator (1.1.0)
-    concurrent-ruby (1.3.4)
-    connection_pool (2.4.1)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.0)
+    csv (3.3.2)
     drb (2.2.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    faraday (2.12.1)
+    faraday (2.12.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    ffi (1.17.0-x86_64-linux-gnu)
-    ffi (1.17.0-x86_64-linux-musl)
+    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.1-x86_64-linux-musl)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
-    google-protobuf (4.29.1-x86_64-linux)
+    google-protobuf (4.29.3)
       bigdecimal
       rake (>= 13)
     html-pipeline (2.14.3)
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.0)
-    i18n (1.14.6)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    jekyll (4.3.4)
+    jekyll (4.4.0)
       addressable (~> 2.4)
+      base64 (~> 0.2)
       colorator (~> 1.0)
+      csv (~> 3.0)
       em-websocket (~> 0.5)
       i18n (~> 1.0)
       jekyll-sass-converter (>= 2.0, < 4.0)
       jekyll-watch (~> 2.0)
+      json (~> 2.6)
       kramdown (~> 2.3, >= 2.3.1)
       kramdown-parser-gfm (~> 1.0)
       liquid (~> 4.0)
-      mercenary (>= 0.3.6, < 0.5)
+      mercenary (~> 0.3, >= 0.3.6)
       pathutil (~> 0.9)
       rouge (>= 3.0, < 5.0)
       safe_yaml (~> 1.0)
@@ -110,7 +115,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.9.0)
+    json (2.9.1)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
     kramdown-parser-gfm (1.1.0)
@@ -119,13 +124,15 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.2)
+    logger (1.6.5)
     mercenary (0.4.0)
-    mini_magick (5.0.1)
+    mini_magick (5.1.0)
     minitest (5.25.4)
     net-http (0.6.0)
       uri
-    nokogiri (1.16.8-x86_64-linux)
+    nokogiri (1.18.2-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.2-x86_64-linux-musl)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -138,17 +145,18 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.9)
+    rexml (3.4.0)
     rouge (4.5.1)
-    rubyzip (2.3.2)
+    rubyzip (2.4.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.82.0)
-      google-protobuf (~> 4.28)
-      rake (>= 13)
+    sass-embedded (1.83.4-x86_64-linux-gnu)
+      google-protobuf (~> 4.29)
+    sass-embedded (1.83.4-x86_64-linux-musl)
+      google-protobuf (~> 4.29)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    securerandom (0.4.0)
+    securerandom (0.4.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     tzinfo (2.0.6)
@@ -162,6 +170,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  google-protobuf
   jekyll
   jekyll-avatar
   jekyll-feed
@@ -185,4 +194,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.25
+   2.5.11

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - ./vendor/bundle:/usr/local/bundle
     environment:
       - JEKYLL_ENV=development
+      - TZ=America/Caracas

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3'
 
 services:
   site:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: jvconseil/jekyll-docker:latest
     command: jekyll serve
     ports:
       - "4000:4000"


### PR DESCRIPTION
- **Use jvconseil/jekyll-docker image directly, define deps in .apk file**
- **Use new branch of my fork of jekyll-thumbnail-img**
- **Use workaround for protobuf on Alpine Linux (fix seg fault)**
- **Update gems**
- **Install apt dependencies from file on GitHub deploy**
- **Use Ruby 3.3, Node 20 on GitHub deploy**
- **Set TZ env variable on docker-compose.yml**
