### PR TITLE
Use inline SVG for Lucide icons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :jekyll_plugins do
   gem "kramdown"
   gem "jekyll-thumbnail-img"
   gem "jekyll-postcss-v2", :git => "https://github.com/S8A/jekyll-postcss-v2.git", :branch => "feature/change_hook_to_site_post_write"
+  gem "jekyll-inline-svg"
 end
 
 # Workaround for segmentation fault on Alpine Linux

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,9 @@ GEM
       octokit (>= 4, < 7, != 4.4.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-inline-svg (1.1.5)
+      jekyll (>= 3.3, < 5.0)
+      svg_optimizer (~> 0.3.0)
     jekyll-mentions (1.6.0)
       html-pipeline (~> 2.3)
       jekyll (>= 3.7, < 5.0)
@@ -188,6 +191,8 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
+    svg_optimizer (0.3.0)
+      nokogiri
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     tzinfo (2.0.6)
@@ -218,6 +223,7 @@ DEPENDENCIES
   jekyll-gist
   jekyll-github-metadata
   jekyll-include-cache
+  jekyll-inline-svg
   jekyll-mentions
   jekyll-optional-front-matter
   jekyll-paginate

--- a/_config.yml
+++ b/_config.yml
@@ -57,3 +57,7 @@ defaults:
       path: ""
     values:
       image: /assets/img/s8a-thumbnail.webp
+
+# jekyll-inline-svg
+svg:
+  optimize: true

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -36,20 +36,25 @@
 
       <div class="flex items-center gap-4">
         <button
-          class="flex items-center justify-center size-8 text-lg rounded-md text-gray-300 hover:bg-gray-800 hover:text-white transition-colors cursor-pointer"
-          x-bind:title="$store.darkMode.on ? 'Toggle light mode' : 'Toggle dark mode'"
+          class="flex items-center justify-center size-8 rounded-md text-gray-300 hover:bg-gray-800 hover:text-white transition-colors cursor-pointer"
+          x-bind:title="$store.darkMode.on ? 'Change to light mode' : 'Change to dark mode'"
           x-on:click="$store.darkMode.toggle()"
         >
-          <i x-bind:class="$store.darkMode.on ? 'icon-moon-star' : 'icon-sun'" aria-hidden="true"></i>
-          <span class="sr-only" x-text="$store.darkMode.on ? 'Toggle light mode' : 'Toggle dark mode'"></span>
+          <template x-if="$store.darkMode.on">
+            {% include lucide-icon.html icon="icon-moon-star" class="size-5" %}
+          </template>
+          <template x-if="!$store.darkMode.on">
+            {% include lucide-icon.html icon="icon-sun" class="size-5" %}
+          </template>
+          <span class="sr-only" x-text="$store.darkMode.on ? 'Change to light mode' : 'Change to dark mode'"></span>
         </button>
         <button
-          class="flex items-center justify-center size-8 text-lg rounded-md transition-colors cursor-pointer sm:hidden"
+          class="flex items-center justify-center size-8 rounded-md transition-colors cursor-pointer sm:hidden"
           x-bind:class="open ? 'bg-gray-900 text-white' : 'text-gray-300 hover:bg-gray-800 hover:text-white'"
           x-on:click="open = !open"
           title="Toggle menu"
         >
-          <i class="icon-menu" aria-hidden="true"></i>
+          {% include lucide-icon.html icon="icon-menu" class="size-5" %}
           <span class="sr-only">Toggle menu</span>
         </button>
       </div>

--- a/_includes/lucide-icon.html
+++ b/_includes/lucide-icon.html
@@ -1,0 +1,18 @@
+{%- capture icon_name -%}
+  {%- assign icon_name_parts = include.icon | split: "-" -%}
+  {%- if icon_name_parts[0] == "icon" -%}
+    {{- include.icon | remove_first: "icon-" -}}
+  {%- else -%}
+    {{- include.icon -}}
+  {%- endif -%}
+{%- endcapture -%}
+{%- assign class = include.class | default: "" -%}
+{%- assign aria_label = include.aria_label | default: "" -%}
+{%- capture aria_hidden -%}
+  {%- if aria_label == "" -%}
+    true
+  {%- else -%}
+    false
+  {%- endif -%}
+{%- endcapture -%}
+{% svg "node_modules/lucide-static/icons/{{ icon_name }}.svg" class="{{ class }}" aria-label="{{ aria_label }}" aria-hidden="{{ aria_hidden }}" %}

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -35,7 +35,10 @@ layout: default
           text-white bg-gray-600 hover:bg-gray-500 dark:bg-gray-500 dark:hover:bg-gray-400
         {%- endif -%}
       {%- endcapture -%}
-      <a href="{{ button.url }}" class="px-4 py-2 rounded-md inline-block {{ button_class_colors }} transition-colors"><i class="{{ button.icon }}" aria-hidden="true"></i> {{ button.text }}</a>
+      <a href="{{ button.url }}" class="flex items-center justify-center gap-1 px-4 py-2 rounded-md {{ button_class_colors }} transition-colors">
+        {% include lucide-icon.html icon=button.icon class="size-4" %}
+        <span>{{ button.text }}</span>
+      </a>
     {%- endfor -%}
   </div>
 {%- endif -%}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5,6 +5,4 @@
 @custom-variant dark (&:where(.dark, .dark *));
 @plugin "@tailwindcss/typography";
 
-@import "lucide-static/font/lucide.css";
-
 @import "./pygments-monokai-tailwind.css";

--- a/index.html
+++ b/index.html
@@ -17,10 +17,10 @@ main_class_extra: divide-y divide-gray-950/5 dark:divide-white/10
       {%- for contact in site.data.contact -%}
       <a
         href="{{ contact.url }}"
-        class="no-underline flex items-center justify-center size-12 text-2xl rounded-lg text-blue-600 hover:bg-gray-100 hover:text-black dark:text-blue-400 dark:hover:bg-gray-800 dark:hover:text-white transition-colors"
+        class="no-underline flex items-center justify-center size-12 rounded-lg text-blue-600 hover:bg-gray-100 hover:text-black dark:text-blue-400 dark:hover:bg-gray-800 dark:hover:text-white transition-colors"
         title="{{ contact.name }}"
       >
-        <i class="{{ contact.icon }}" aria-hidden="true"></i>
+        {% include lucide-icon.html icon=contact.icon class="size-6" %}
         <span class="sr-only">{{ contact.name }}</span>
       </a>
       {%- endfor -%}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,21 +3,5 @@ import path from "path";
 export default {
     plugins: {
         "@tailwindcss/postcss": {},
-        "postcss-url": [
-            {
-                filter: /lucide\.(woff.?|ttf|svg|eot)$/,
-                url: "copy",
-                // Now Tailwind moves the font files so that they end up as
-                // ../../../node_modules/lucide-static/font/lucide.ext
-                basePath: path.resolve("node_modules/lucide-static/font"),
-                // Thus, if we set ../fonts it wont't end up as
-                // /assets/fonts/lucide.ext like we want, but rather as 
-                // /node_modules/lucide-static/font/lucide.ext, because
-                // the aforementioned relative path is such that it will
-                // go up three levels above /assets/fonts. That's why
-                // we set this dummy folder name
-                assetsPath: "./path-goes-up-three-levels-ignoring-this",
-            },
-        ],
     },
 };


### PR DESCRIPTION
- **Install jekyll-inline-svg**
- **Enable inline SVG optimization in _config.yml**
- **Create include for Lucide SVG icons**
- **Use inline SVG to include all Lucide icons**
- **Remove Lucide icon font & CSS**
